### PR TITLE
Remove flags with a ! (bang) prefix

### DIFF
--- a/_docker.sh.bats
+++ b/_docker.sh.bats
@@ -29,3 +29,27 @@ DOCKER_IMAGE="image:1.2.3"
 	exp=(run -e QUX=quux --entrypoint /foo image:1.2.3 --version)
 	[[ "$results" = "${exp[@]}" ]]
 }
+
+@test "remove flag using the ! bang option" {
+	COMMAND_LINE_ARGS=(--version -- !--rm)
+	results=$(run_with --rm -it)
+
+	echo "${results[@]}"
+	exp=(run -it image:1.2.3 --version)
+	[[ "$results" = "${exp[@]}" ]]
+}
+
+@test "contains returns boolean based on need vs haystack" {
+	results=$(contains "-it" "--rm -it")
+	echo "$results"
+	exp=true
+	[[ "$results" = "$exp" ]]
+}
+
+@test "pop removes the given from flag(s) from annother array of flags" {
+	args=("--rm -it --entrypoint foo")
+	results=$(pop "-it --rm" ${args[@]})
+	echo "$results"
+	exp=(" --entrypoint foo") # FIXME what is with the extra space before --entrypoint...?
+	[[ "$results" = "${exp[@]}" ]]
+}


### PR DESCRIPTION
This PR contains a feature to remove flags from an existing list of flags by prefixing the flag to be removed with a `!` (bang). 

Assuming your wrappers have a default flag list of

```
--rm -it
```

To remove a flag, you would prefix the flag you desired removed with a bang (assumes the wrapper is for `go`)

```
go -- !--rm
```

This will remove the `--rm` flag from the final docker run command.
